### PR TITLE
Append final newline in read_line_initial_text

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -320,7 +320,10 @@ impl Term {
                     self.write_str(chr.encode_utf8(&mut bytes_char))?;
                     self.flush()?;
                 }
-                Key::Enter => break,
+                Key::Enter => {
+                    self.write_line("")?;
+                    break;
+                }
                 Key::Unknown => {
                     return Err(io::Error::new(
                         io::ErrorKind::NotConnected,


### PR DESCRIPTION
Proposed fix for [issue 112](https://github.com/console-rs/console/issues/112)

Note that this changes the behaviour of `Term::read_line_initial_text()` to make it consistent with `Term:read_line()`. No change to the return value, but a change in side effects.