### PR TITLE
read_char: Handle non-tty terminals explicitly

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -245,8 +245,15 @@ impl Term {
     /// Read a single character from the terminal.
     ///
     /// This does not echo the character and blocks until a single character
-    /// is entered.
+    /// or complete key chord is entered.  If the terminal is not user attended
+    /// the return value will be an error.
     pub fn read_char(&self) -> io::Result<char> {
+        if !self.is_tty {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "Not a terminal",
+            ));
+        }
         loop {
             match self.read_key()? {
                 Key::Char(c) => {
@@ -254,12 +261,6 @@ impl Term {
                 }
                 Key::Enter => {
                     return Ok('\n');
-                }
-                Key::Unknown => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "Not a terminal",
-                    ))
                 }
                 _ => {}
             }
@@ -323,12 +324,6 @@ impl Term {
                 Key::Enter => {
                     self.write_line("")?;
                     break;
-                }
-                Key::Unknown => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "Not a terminal",
-                    ))
                 }
                 _ => (),
             }


### PR DESCRIPTION
`Key::Unknown` is produced only when:
- A keycode is not recognized by the `key_from_key_code` function under Windows: https://github.com/console-rs/console/blob/b3ecb7dd71b40c368f4fd6a18a04a2fe057bb0a0/src/windows_term.rs#L337
- `read_key` is invoked on a non-tty terminal: https://github.com/console-rs/console/blob/b3ecb7dd71b40c368f4fd6a18a04a2fe057bb0a0/src/term.rs#L274-L276

The two places in the code which explicitly handled `Key::Unknown` were treating it as a proxy for an "unattended terminal" check:
https://github.com/console-rs/console/blob/b3ecb7dd71b40c368f4fd6a18a04a2fe057bb0a0/src/term.rs#L258-L263

Since this is only 100% valid to do when running under *nix I've replaced these handlers with an explicit `!self.is_tty` check instead, which is a common pattern in the Term code. `Key::Unknown` is now assumed to represent an unprintable / control key and skipped when being evaluated.

I found this issue when pressing the `Ctrl` key while using the `read_key` function, which causes it to return `Err(Not a terminal)` under Windows (but works fine on Linux). In this case, I was in the process of pressing `Ctrl + C` in order to terminate the program.
It looks like this issue also occurred previously for the `Shift` and `Alt` keys under Windows - rather than extend the `Keys` enum further to support the `Ctrl` key I think the proposed fix is a little more future proof (though you may like to add support for [VK_CONTROL](https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes) for the sake of completeness anyway).
- https://github.com/console-rs/console/issues/83
- https://github.com/console-rs/console/issues/102

