### PR TITLE
Drop once_cell because of MSRV bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ windows-console-colors = ["ansi-parsing", "regex", "winapi-util"]
 ansi-parsing = []
 
 [dependencies]
-once_cell = "1"
 libc = "0.2.30"
 terminal_size = "0.1.14"
 regex = { version = "1.4.2", optional = true, default-features = false, features = ["std"] }
 unicode-width = { version = "0.1", optional = true }
+lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "winuser", "consoleapi", "processenv", "wincon"] }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -271,18 +271,18 @@ impl<'a> FusedIterator for AnsiCodeIterator<'a> {}
 mod tests {
     use super::*;
 
-    use once_cell::sync::Lazy;
+    use lazy_static::lazy_static;
     use proptest::prelude::*;
     use regex::Regex;
 
     // The manual dfa `State` is a handwritten translation from the previously used regex. That
     // regex is kept here and used to ensure that the new matches are the same as the old
-    static STRIP_ANSI_RE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(
-        r"[\x1b\x9b]([()][012AB]|[\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><])",
-            )
-            .unwrap()
-    });
+    lazy_static! {
+        static ref STRIP_ANSI_RE: Regex = Regex::new(
+            r"[\x1b\x9b]([()][012AB]|[\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><])",
+        )
+        .unwrap();
+    }
 
     impl<'a, 'b> PartialEq<Match<'a>> for regex::Match<'b> {
         fn eq(&self, other: &Match<'a>) -> bool {

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -271,11 +271,12 @@ pub fn key_from_utf8(buf: &[u8]) -> Key {
 }
 
 #[cfg(not(target_os = "macos"))]
-static IS_LANG_UTF8: once_cell::sync::Lazy<bool> =
-    once_cell::sync::Lazy::new(|| match std::env::var("LANG") {
+lazy_static::lazy_static! {
+    static ref IS_LANG_UTF8: bool = match std::env::var("LANG") {
         Ok(lang) => lang.to_uppercase().ends_with("UTF-8"),
         _ => false,
-    });
+    };
+}
 
 #[cfg(target_os = "macos")]
 pub fn wants_emoji() -> bool {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,9 @@ use std::env;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use lazy_static::lazy_static;
+
 use crate::term::{wants_emoji, Term};
-use once_cell::sync::Lazy;
 
 #[cfg(feature = "ansi-parsing")]
 use crate::ansi::{strip_ansi_codes, AnsiCodeIterator};
@@ -21,10 +22,10 @@ fn default_colors_enabled(out: &Term) -> bool {
         || &env::var("CLICOLOR_FORCE").unwrap_or_else(|_| "0".into()) != "0"
 }
 
-static STDOUT_COLORS: Lazy<AtomicBool> =
-    Lazy::new(|| AtomicBool::new(default_colors_enabled(&Term::stdout())));
-static STDERR_COLORS: Lazy<AtomicBool> =
-    Lazy::new(|| AtomicBool::new(default_colors_enabled(&Term::stderr())));
+lazy_static! {
+    static ref STDOUT_COLORS: AtomicBool = AtomicBool::new(default_colors_enabled(&Term::stdout()));
+    static ref STDERR_COLORS: AtomicBool = AtomicBool::new(default_colors_enabled(&Term::stderr()));
+}
 
 /// Returns `true` if colors should be enabled for stdout.
 ///

--- a/src/windows_term.rs
+++ b/src/windows_term.rs
@@ -38,16 +38,14 @@ use crate::kb::Key;
 use crate::term::{Term, TermTarget};
 
 #[cfg(feature = "windows-console-colors")]
-use once_cell::sync::Lazy;
-#[cfg(feature = "windows-console-colors")]
 use regex::Regex;
+
 #[cfg(feature = "windows-console-colors")]
-static INTENSE_COLOR_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\x1b\[(3|4)8;5;(8|9|1[0-5])m").unwrap());
-#[cfg(feature = "windows-console-colors")]
-static NORMAL_COLOR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[(3|4)([0-7])m").unwrap());
-#[cfg(feature = "windows-console-colors")]
-static ATTR_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[([1-8])m").unwrap());
+lazy_static::lazy_static! {
+    static ref INTENSE_COLOR_RE: Regex = Regex::new(r"\x1b\[(3|4)8;5;(8|9|1[0-5])m").unwrap();
+    static ref NORMAL_COLOR_RE: Regex = Regex::new(r"\x1b\[(3|4)([0-7])m").unwrap();
+    static ref ATTR_RE: Regex = Regex::new(r"\x1b\[([1-8])m").unwrap();
+}
 
 const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x4;
 pub const DEFAULT_WIDTH: u16 = 79;


### PR DESCRIPTION
This removes `once_cell` again because of the recent MSRV bump. See https://github.com/matklad/once_cell/issues/201

I will revisit this at a later point, for now I just want to postpone the MSRV discussion for a bit.

Refs #134