### PR TITLE
Derive Hash for Key

### DIFF
--- a/src/kb.rs
+++ b/src/kb.rs
@@ -3,7 +3,7 @@
 /// This is an incomplete mapping of keys that are supported for reading
 /// from the keyboard.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Key {
     Unknown,
     /// Unrecognized sequence containing Esc and a list of chars


### PR DESCRIPTION
I was writing a quick console game, and I tried to make a `HashMap<Key>`. Unfortunately, Key doesn't derive Hash, though there's no reason why it can't.

Tiny PR, I know, but I think it's helpful and somebody had to add those 6 characters.
