### PR TITLE
Don't touch output config attributes in read_single_key()

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -163,6 +163,7 @@ pub fn read_single_key() -> io::Result<Key> {
     let mut termios = unsafe { termios.assume_init() };
     let original = termios;
     unsafe { libc::cfmakeraw(&mut termios) };
+    termios.c_oflag = original.c_oflag;
     c_result(|| unsafe { libc::tcsetattr(fd, libc::TCSADRAIN, &termios) })?;
 
     let rv = match read_single_char(fd)? {


### PR DESCRIPTION
Raw mode also disables output processing, breaking terminal writes from separate threads. Fixes #136.