### PR TITLE
Working fix for #108

### DIFF
--- a/src/kb.rs
+++ b/src/kb.rs
@@ -27,3 +27,58 @@ pub enum Key {
     PageDown,
     Char(char),
 }
+
+/// Converts a slice of `Key` enum values to a UTF-8 encoded `String`.
+///Will add newlines for Key::Enter and delete the last char for Key::BackSpace
+///
+/// # Arguments
+///
+/// * `keys` - A slice of `Key` enum values representing user input keys.
+pub fn keys_to_utf8(keys: &[Key]) -> String {
+    let mut chars = Vec::new();
+    for key in keys {
+        match key {
+            Key::Char(c) => chars.push(c),
+            Key::Backspace => {
+                chars.pop();
+            }
+            #[cfg(not(windows))]
+            Key::Enter => chars.push(&'\n'),
+            #[cfg(windows)]
+            Key::Enter => {
+                chars.push(&'\r');
+                chars.push(&'\n')
+            }
+            key => {
+                // This may be expanded by keeping track of a cursor which is controlled by the ArrowKeys and changes del and backspace
+                unimplemented!("Cannot convert key: {:?} to utf8", key)
+            }
+        }
+    }
+    chars.into_iter().collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keys_to_utf8() {
+        let keys = vec![
+            Key::Char('H'),
+            Key::Char('e'),
+            Key::Char('l'),
+            Key::Char('l'),
+            Key::Char('o'),
+            Key::Enter,
+            Key::Char('W'),
+            Key::Char('o'),
+            Key::Char('r'),
+            Key::Char('l'),
+            Key::Char('d'),
+            Key::Backspace,
+        ];
+        let result = keys_to_utf8(&keys);
+        assert_eq!(result, "Hello\nWorl");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 //! * `ansi-parsing`: adds support for parsing ansi codes (this adds support
 //!   for stripping and taking ansi escape codes into account for length
 //!   calculations).
+#![feature(io_error_more)]
 
 pub use crate::kb::Key;
 pub use crate::term::{

--- a/src/term.rs
+++ b/src/term.rs
@@ -92,8 +92,18 @@ impl TermTarget {
             io::stdin().read_line(buf)
         }
     }
+
+    /// Read a line from the input source without showing the inserted characters
+    /// # Panics
+    /// If the input source is a custom ReadWritePair and any keys other than Char, Enter or BackSpace are encountered
+    ///
+    /// # Returns error
+    /// If there was an error reading from the input source
+    ///
+    /// # Returns ok
+    /// The read line
     fn read_secure(&self) -> io::Result<String> {
-        if let TermTarget::ReadWritePair(pair) = self {
+        if let TermTarget::ReadWritePair(_) = self {
             let mut s = String::new();
             self.read_line(&mut s)?;
             Ok(s)

--- a/src/term.rs
+++ b/src/term.rs
@@ -11,13 +11,11 @@ use crate::{kb::Key, utils::Style};
 
 #[cfg(unix)]
 trait TermWrite: Write + Debug + AsRawFd + Send {}
-#[cfg(unix)]
 impl<T: Write + Debug + AsRawFd + Send> TermWrite for T {}
 
 #[cfg(unix)]
-trait TermRead: Read + Debug + AsRawFd + Send {}
-#[cfg(unix)]
-impl<T: Read + Debug + AsRawFd + Send> TermRead for T {}
+trait TermRead: Iterator<Item = Key> + Debug + AsRawFd + Send {}
+impl<T: Iterator<Item = Key> + Debug + AsRawFd + Send> TermRead for T {}
 
 #[cfg(unix)]
 #[derive(Debug, Clone)]
@@ -181,7 +179,7 @@ impl Term {
     #[cfg(unix)]
     pub fn read_write_pair<R, W>(read: R, write: W) -> Term
     where
-        R: Read + Debug + AsRawFd + Send + 'static,
+        R: Iterator<Item = Key> + Debug + AsRawFd + Send + 'static,
         W: Write + Debug + AsRawFd + Send + 'static,
     {
         Self::read_write_pair_with_style(read, write, Style::new().for_stderr())
@@ -191,7 +189,7 @@ impl Term {
     #[cfg(unix)]
     pub fn read_write_pair_with_style<R, W>(read: R, write: W, style: Style) -> Term
     where
-        R: Read + Debug + AsRawFd + Send + 'static,
+        R: Iterator<Item = Key> + Debug + AsRawFd + Send + 'static,
         W: Write + Debug + AsRawFd + Send + 'static,
     {
         Term::with_inner(TermInner {
@@ -210,7 +208,6 @@ impl Term {
         match self.inner.target {
             TermTarget::Stderr => Style::new().for_stderr(),
             TermTarget::Stdout => Style::new().for_stdout(),
-            #[cfg(unix)]
             TermTarget::ReadWritePair(ReadWritePair { ref style, .. }) => style.clone(),
         }
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -63,9 +63,31 @@ impl TermTarget {
             io::stdin().read(buf)
         }
     }
+
+    /// Reads chars until Key::Enter was found
+    /// This may cause an infinite loop if the line is not terminated
+    ///
+    /// # Panics
+    /// If the input source is a custom ReadWritePair and any keys other than Char, Enter or BackSpace are encountered
+    ///
+    /// # Returns error
+    /// If there was an error reading from the input source
+    ///
+    /// # Returns ok
+    /// The length of the modified buffer string
     fn read_line(&self, buf: &mut String) -> io::Result<usize> {
-        if let TermTarget::ReadWritePair(pair) = self {
-            todo!()
+        if let TermTarget::ReadWritePair(_) = self {
+            let mut keys = Vec::new();
+            loop {
+                let key = self.read_single_key()?;
+                if key == Key::Enter {
+                    break;
+                }
+                keys.push(key);
+            }
+            buf.clear();
+            buf.push_str(&keys_to_utf8(&keys));
+            Ok(buf.len())
         } else {
             io::stdin().read_line(buf)
         }


### PR DESCRIPTION
Currently console only reads input from stdin. However a ReadWritePair option has already been added. Unfortunately only writing works for ReadWritePair. This PR adds functionality for a custom input source.

Therefore the following lines have been changed:
- https://github.com/console-rs/console/blob/51425fca70702b74ea64b29984da103a5bcbc7bc/src/term.rs#L291
- https://github.com/console-rs/console/blob/51425fca70702b74ea64b29984da103a5bcbc7bc/src/term.rs#L617
- https://github.com/console-rs/console/blob/51425fca70702b74ea64b29984da103a5bcbc7bc/src/term.rs#L623
- https://github.com/console-rs/console/blob/51425fca70702b74ea64b29984da103a5bcbc7bc/src/term.rs#L343
- https://github.com/console-rs/console/blob/51425fca70702b74ea64b29984da103a5bcbc7bc/src/term.rs#L278

ReadWritePair was also modified. Previously it required an input source of type Read (enables reading of bytes)  
This has been changed to an iterator over Keys because Keys are a cross platform solution. Else we would need to parse the input differently depending on the os of the user. Now the user has a nice interface for defining his own input source.

Functionality may be expanded in the future to support more keys, or to automatically convert something like Key::Char('\n') to Key::Enter or at least warn the user.  
This pr should be a good start adding an essential feature.  
Please take a look at the commits from last to newest. They contain a description of what has been changed.