### PR TITLE
Support build target `wasm32-unknown-emscripten`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [wasm32-unknown-unknown]
+        include:
+          - target: wasm32-unknown-unknown
+            os: ubuntu-latest
+          - target: wasm32-unknown-emscripten
+            os: ubuntu-latest
+          - target: wasm32-unknown-emscripten
+            os: windows-latest
+          - target: wasm32-unknown-emscripten
+            os: macos-latest
     runs-on: ubuntu-latest
     steps:
       - name: Install rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use crate::ansi::{strip_ansi_codes, AnsiCodeIterator};
 mod common_term;
 mod kb;
 mod term;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 mod unix_term;
 mod utils;
 #[cfg(target_arch = "wasm32")]

--- a/src/term.rs
+++ b/src/term.rs
@@ -108,7 +108,7 @@ impl<'a> TermFeatures<'a> {
         {
             TermFamily::WindowsConsole
         }
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_arch = "wasm32")))]
         {
             TermFamily::UnixTerm
         }
@@ -624,7 +624,7 @@ impl<'a> Read for &'a Term {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 pub use crate::unix_term::*;
 #[cfg(target_arch = "wasm32")]
 pub use crate::wasm_term::*;


### PR DESCRIPTION
Hi @console-rs members!

I found that `#[cfg(unix)]` and `#[cfg(target_arch = "wasm32")]` conflicted when building with `wasm32-unknown-emscripten` as the target, so I changed `#[cfg(unix)]` to `#[cfg(all(unix, not(target_arch = "wasm32")))]` to resolve the conflict.

## Current behavior

```sh
cargo check --target wasm32-unknown-emscripten
```
failed on unix
<details>

```
(/home/runner/work/console/console)
error[E0659]: `wants_emoji` is ambiguous
   --> src/utils.rs:9:19
    |
9   | use crate::term::{wants_emoji, Term};
    |                   ^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `wants_emoji` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `wants_emoji` to disambiguate
note: `wants_emoji` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `wants_emoji` to disambiguate

error[E0659]: `is_a_terminal` is ambiguous
   --> src/term.rs:67:9
    |
67  |         is_a_terminal(self.0)
    |         ^^^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `is_a_terminal` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `is_a_terminal` to disambiguate
note: `is_a_terminal` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `is_a_terminal` to disambiguate

error[E0659]: `is_a_color_terminal` is ambiguous
   --> src/term.rs:76:9
    |
76  |         is_a_color_terminal(self.0)
    |         ^^^^^^^^^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `is_a_color_terminal` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `is_a_color_terminal` to disambiguate
note: `is_a_color_terminal` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `is_a_color_terminal` to disambiguate

error[E0659]: `wants_emoji` is ambiguous
   --> src/term.rs:98:31
    |
98  |         self.is_attended() && wants_emoji()
    |                               ^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `wants_emoji` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `wants_emoji` to disambiguate
note: `wants_emoji` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `wants_emoji` to disambiguate

error[E0659]: `read_single_key` is ambiguous
   --> src/term.rs:278:13
    |
278 |             read_single_key()
    |             ^^^^^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `read_single_key` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `read_single_key` to disambiguate
note: `read_single_key` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `read_single_key` to disambiguate

error[E0659]: `read_secure` is ambiguous
   --> src/term.rs:343:15
    |
343 |         match read_secure() {
    |               ^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `read_secure` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `read_secure` to disambiguate
note: `read_secure` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `read_secure` to disambiguate

error[E0659]: `DEFAULT_WIDTH` is ambiguous
   --> src/term.rs:383:44
    |
383 |         self.size_checked().unwrap_or(([24](https://github.com/ChanTsune/console/actions/runs/5775408258/job/15653363901#step:4:25), DEFAULT_WIDTH))
    |                                            ^^^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `DEFAULT_WIDTH` could refer to the constant imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `DEFAULT_WIDTH` to disambiguate
note: `DEFAULT_WIDTH` could also refer to the constant imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `DEFAULT_WIDTH` to disambiguate

error[E0659]: `terminal_size` is ambiguous
   --> src/term.rs:391:9
    |
391 |         terminal_size(self)
    |         ^^^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `terminal_size` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `terminal_size` to disambiguate
note: `terminal_size` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `terminal_size` to disambiguate

error[E0659]: `set_title` is ambiguous
   --> src/term.rs:483:9
    |
483 |         set_title(title);
    |         ^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `set_title` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `set_title` to disambiguate
note: `set_title` could also refer to the function imported here
   --> src/term.rs:630:9
    |
630 | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `set_title` to disambiguate

error[E0659]: `wants_emoji` is ambiguous
   --> src/utils.rs:701:12
    |
701 |         if wants_emoji() {
    |            ^^^^^^^^^^^ ambiguous name
    |
    = note: ambiguous because of multiple glob imports of a name in the same module
note: `wants_emoji` could refer to the function imported here
   --> src/term.rs:628:9
    |
628 | pub use crate::unix_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `wants_emoji` to disambiguate
note: `wants_emoji` could also refer to the function imported here
   --> src/term.rs:630:9
    |
6[30](https://github.com/ChanTsune/console/actions/runs/5775408258/job/15653363901#step:4:31) | pub use crate::wasm_term::*;
    |         ^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `wants_emoji` to disambiguate

warning: unused import: `std::mem`
 --> src/unix_term.rs:6:5
  |
6 | use std::mem;
  |     ^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::ptr`
 --> src/unix_term.rs:8:5
  |
8 | use std::ptr;
  |     ^^^^^^^^

error[E0308]: mismatched types
   --> src/term.rs:113:13
    |
113 |             TermFamily::UnixTerm
    |             ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `TermFamily`
    |
help: you might have meant to return this value
    |
113 |             return TermFamily::UnixTerm;
    |             ++++++                     +

Some errors have detailed explanations: E0308, E06[59](https://github.com/ChanTsune/console/actions/runs/5775408258/job/15653363901#step:4:60).
For more information about an error, try `rustc --explain E0308`.
warning: `console` (lib) generated 2 warnings
error: could not compile `console` (lib) due to 11 previous errors; 2 warnings emitted
```
</details>
