### PR TITLE
Update read_line behaviour to read_line_initial_text

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -284,14 +284,7 @@ impl Term {
     /// This does not include the trailing newline.  If the terminal is not
     /// user attended the return value will always be an empty string.
     pub fn read_line(&self) -> io::Result<String> {
-        if !self.is_tty {
-            return Ok("".into());
-        }
-        let mut rv = String::new();
-        io::stdin().read_line(&mut rv)?;
-        let len = rv.trim_end_matches(&['\r', '\n'][..]).len();
-        rv.truncate(len);
-        Ok(rv)
+        self.read_line_initial_text("")
     }
 
     /// Read one line of input with initial text.


### PR DESCRIPTION
`term.read_line()` is not using the declared term to request the input. It relies on stdin. This is not the case of `term.read_line_initial_text("")`, which reads key one by one using `self.read_key()`.

This commits corrects this behaviour, and removes divergence between the two methods.

If `read_line` and `read_line_initial_text` are meant to have a different behaviour, their documentation needs to be updated. I'd be glad to update this PR if that's the case.