### PR TITLE
Return `Key::Tab` instead of `Key::Char(\t)` on Windows

### DIFF
--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -390,6 +390,8 @@ pub fn read_single_key() -> io::Result<Key> {
                 // a special keycode for `Enter`, while ReadConsoleInputW() prefers to use '\r'.
                 if c == '\r' {
                     Ok(Key::Enter)
+                } else if c == '\t' {
+                    Ok(Key::Tab)
                 } else if c == '\x08' {
                     Ok(Key::Backspace)
                 } else if c == '\x1B' {


### PR DESCRIPTION
On Windows, `Key::Tab` needs to be handled specially.

This affects code like https://github.com/console-rs/dialoguer/blob/master/src/prompts/input.rs#L474

This PR is tested on `conhost.exe` and the new Console Host from Windows 11.
