### PR TITLE
Use `out.as_raw_fd()` to get size in `unix_term`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+* Properly use configured output of `Term` to get terminal size (#186)
+
 ## 0.15.7
 
 ### Enhancements

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -46,7 +46,7 @@ pub fn c_result<F: FnOnce() -> libc::c_int>(f: F) -> io::Result<()> {
 
 pub fn terminal_size(out: &Term) -> Option<(u16, u16)> {
     unsafe {
-        if libc::isatty(libc::STDOUT_FILENO) != 1 {
+        if libc::isatty(out.as_raw_fd()) != 1 {
             return None;
         }
 


### PR DESCRIPTION
Fixes #185. Tested as a resolution to https://github.com/pantsbuild/pants/pull/19931#issuecomment-1732652244 where the line is always truncated at 80 chars.