### PR TITLE
[WIP][PoC] Return `Ctrl+C` instead of SIGINT

### DIFF
--- a/src/kb.rs
+++ b/src/kb.rs
@@ -26,4 +26,5 @@ pub enum Key {
     PageUp,
     PageDown,
     Char(char),
+    CtrlC,
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -275,7 +275,15 @@ impl Term {
         if !self.is_tty {
             Ok(Key::Unknown)
         } else {
-            read_single_key()
+            read_single_key(false)
+        }
+    }
+
+    pub fn read_key_raw(&self) -> io::Result<Key> {
+        if !self.is_tty {
+            Ok(Key::Unknown)
+        } else {
+            read_single_key(true)
         }
     }
 

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -295,7 +295,7 @@ fn read_single_key_impl(fd: i32) -> Result<Key, io::Error> {
     }
 }
 
-pub fn read_single_key() -> io::Result<Key> {
+pub fn read_single_key(ctrlc_key: bool) -> io::Result<Key> {
     let tty_f;
     let fd = unsafe {
         if libc::isatty(libc::STDIN_FILENO) == 1 {
@@ -321,8 +321,12 @@ pub fn read_single_key() -> io::Result<Key> {
     // if the user hit ^C we want to signal SIGINT to outselves.
     if let Err(ref err) = rv {
         if err.kind() == io::ErrorKind::Interrupted {
-            unsafe {
-                libc::raise(libc::SIGINT);
+            if !ctrlc_key {
+                unsafe {
+                    libc::raise(libc::SIGINT);
+                }
+            } else {
+                return Ok(Key::CtrlC);
             }
         }
     }


### PR DESCRIPTION
Would it be an acceptable option to deal with a "`Ctrl+C` problem" (issue #172)?
**Problem**: SIGINT leaves the terminal in a raw mode or keeps a hidden cursor, and also, it's impossible to handle Ctrl+C gracefully.

This PoC works on Linux as of now.
Tested with [`cliclack`](https://github.com/fadeevab/cliclack/)