### PR TITLE
Fix behavior of `read_line_initial_text`

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -234,7 +234,10 @@ impl Term {
     /// Write a string to the terminal and add a newline.
     pub fn write_line(&self, s: &str) -> io::Result<()> {
         let prompt = self.prompt.read().unwrap();
-        self.clear_chars(prompt.len())?;
+        // self.clear_chars(prompt.len())?;
+        if !prompt.is_empty() {
+            self.clear_line()?;
+        }
         match self.inner.buffer {
             Some(ref mutex) => {
                 let mut buffer = mutex.lock().unwrap();

--- a/src/term.rs
+++ b/src/term.rs
@@ -244,7 +244,7 @@ impl Term {
     /// Write a string to the terminal and add a newline.
     pub fn write_line(&self, s: &str) -> io::Result<()> {
         let prompt = self.inner.prompt.read().unwrap();
-        self.clear_chars(prompt.len())?;
+        // self.clear_chars(prompt.len())?;
         /*if !prompt.is_empty() {
             self.clear_line()?;
         }*/

--- a/src/term.rs
+++ b/src/term.rs
@@ -233,12 +233,15 @@ impl Term {
     pub fn write_line(&self, s: &str) -> io::Result<()> {
         match self.inner.buffer {
             Some(ref mutex) => {
+                println!("got buffer!");
                 let mut buffer = mutex.lock().unwrap();
                 buffer.extend_from_slice(s.as_bytes());
                 buffer.push(b'\n');
                 Ok(())
             }
-            None => self.write_through(format!("{}\n", s).as_bytes()),
+            None => {
+                println!("got no buffer!");
+                self.write_through(format!("{}\n", s).as_bytes()),
         }
     }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -244,10 +244,10 @@ impl Term {
     /// Write a string to the terminal and add a newline.
     pub fn write_line(&self, s: &str) -> io::Result<()> {
         let prompt = self.inner.prompt.read().unwrap();
-        // self.clear_chars(prompt.len())?;
-        if !prompt.is_empty() {
+        self.clear_chars(prompt.len())?;
+        /*if !prompt.is_empty() {
             self.clear_line()?;
-        }
+        }*/
         match self.inner.buffer {
             Some(ref mutex) => {
                 let mut buffer = mutex.lock().unwrap();
@@ -354,7 +354,6 @@ impl Term {
                         }
                         _ => (),
                     }
-                
             }
             Ok(chars.iter().skip(prefix_len).collect::<String>())
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -304,12 +304,14 @@ impl Term {
         }
         self.write_str(initial)?;
 
+        let prefix_len = initial.len();
+
         let mut chars: Vec<char> = initial.chars().collect();
 
         loop {
             match self.read_key()? {
                 Key::Backspace => {
-                    if chars.pop().is_some() {
+                    if prefix_len < chars.len() && chars.pop().is_some() {
                         self.clear_chars(1)?;
                     }
                     self.flush()?;
@@ -328,7 +330,7 @@ impl Term {
                 _ => (),
             }
         }
-        Ok(chars.iter().collect::<String>())
+        Ok(chars.iter().skip(prefix_len).collect::<String>())
     }
 
     /// Read a line of input securely.

--- a/src/term.rs
+++ b/src/term.rs
@@ -244,10 +244,9 @@ impl Term {
     /// Write a string to the terminal and add a newline.
     pub fn write_line(&self, s: &str) -> io::Result<()> {
         let prompt = self.inner.prompt.read().unwrap();
-        // self.clear_chars(prompt.len())?;
-        /*if !prompt.is_empty() {
+        if !prompt.is_empty() {
             self.clear_line()?;
-        }*/
+        }
         match self.inner.buffer {
             Some(ref mutex) => {
                 let mut buffer = mutex.lock().unwrap();
@@ -315,7 +314,9 @@ impl Term {
     }
 
     /// Read one line of input with initial text.
-    ///
+    /// 
+    /// This method blocks until no other thread is waiting for this read_line
+    /// before reading a line from the terminal.
     /// This does not include the trailing newline.  If the terminal is not
     /// user attended the return value will always be an empty string.
     pub fn read_line_initial_text(&self, initial: &str) -> io::Result<String> {

--- a/src/term.rs
+++ b/src/term.rs
@@ -339,7 +339,7 @@ impl Term {
                             slf.flush()?;
                         }
                         Key::Enter => {
-                            slf.write_line("")?;
+                            slf.write_through(format!("\n{}", initial).as_bytes())?;
                             break;
                         }
                         _ => (),

--- a/src/term.rs
+++ b/src/term.rs
@@ -242,13 +242,13 @@ impl Term {
             Some(ref mutex) => {
                 let mut buffer = mutex.lock().unwrap();
                 buffer.extend_from_slice(s.as_bytes());
+                buffer.push(b'\r');
                 buffer.push(b'\n');
                 buffer.extend_from_slice(prompt.as_bytes());
                 Ok(())
             }
             None => {
-                self.write_through(format!("{}\n", s).as_bytes())?;
-                self.write_through(prompt.as_bytes())
+                self.write_through(format!("{}\n{}", s, prompt.as_str()).as_bytes())
             }
         }
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -242,6 +242,7 @@ impl Term {
             None => {
                 println!("got no buffer!");
                 self.write_through(format!("{}\n", s).as_bytes())
+            }
         }
     }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -241,7 +241,7 @@ impl Term {
             }
             None => {
                 println!("got no buffer!");
-                self.write_through(format!("{}\n", s).as_bytes()),
+                self.write_through(format!("{}\n", s).as_bytes())
         }
     }
 


### PR DESCRIPTION
This makes it so one can't delete any of the initial text using the backspace keys, that the read_line_initial_text method can only be enter by one thread at a time and that the initial prefix will be retained across write_line calls.