### PR TITLE
Added a function that reads a key with cursor hidden

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -292,15 +292,25 @@ impl Term {
         if !self.is_tty {
             Ok(Key::Unknown)
         } else {
-            read_single_key(false)
+            read_single_key(false, false)
         }
     }
 
+    /// Like [`read_key`](Self::read_key) but disables the cursor.
+    pub fn read_key_no_cursor(&self) -> io::Result<Key> {
+        if !self.is_tty {
+            Ok(Key::Unknown)
+        } else {
+            read_single_key(false, true)
+        }
+    }
+
+    /// Like [`read_key`](Self::read_key) but it can catch `CtrlC`.
     pub fn read_key_raw(&self) -> io::Result<Key> {
         if !self.is_tty {
             Ok(Key::Unknown)
         } else {
-            read_single_key(true)
+            read_single_key(true, false)
         }
     }
 

--- a/src/wasm_term.rs
+++ b/src/wasm_term.rs
@@ -39,7 +39,7 @@ pub fn read_secure() -> io::Result<String> {
     ))
 }
 
-pub fn read_single_key(_ctrlc_key: bool) -> io::Result<Key> {
+pub fn read_single_key(_ctrlc_key: bool, _hide_cursor: bool) -> io::Result<Key> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         "unsupported operation",

--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -354,7 +354,7 @@ pub fn key_from_key_code(code: VIRTUAL_KEY) -> Key {
 pub fn read_secure() -> io::Result<String> {
     let mut rv = String::new();
     loop {
-        match read_single_key(false)? {
+        match read_single_key(false, false)? {
             Key::Enter => {
                 break;
             }
@@ -373,7 +373,7 @@ pub fn read_secure() -> io::Result<String> {
     Ok(rv)
 }
 
-pub fn read_single_key(_ctrlc_key: bool) -> io::Result<Key> {
+pub fn read_single_key(_ctrlc_key: bool, _hide_cursor: bool) -> io::Result<Key> {
     let key_event = read_key_event()?;
 
     let unicode_char = unsafe { key_event.uChar.UnicodeChar };


### PR DESCRIPTION
Proposed API to read a key with cursor hidden. This would make the common case of cursors disappearing on ctrl-c less common as this is the most common case right now where cursors are hidden.

So rather than hiding cursors all the time, this would hide the cursor just while waiting for the key press and reset it afterwards.

Refs https://github.com/console-rs/dialoguer/issues/294