### PR TITLE
Moved from unicode-width to unicode-display-width for visual grapheme width estimation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "console"
 description = "A terminal and console abstraction for Rust"
-version = "0.15.8"
+version = "0.16.0"
 keywords = ["cli", "terminal", "colors", "console", "ansi"]
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 license = "MIT"
@@ -13,13 +13,13 @@ readme = "README.md"
 rust-version = "1.56.0"
 
 [features]
-default = ["unicode-width", "ansi-parsing"]
+default = ["unicode-display-width", "ansi-parsing"]
 windows-console-colors = ["ansi-parsing"]
 ansi-parsing = []
 
 [dependencies]
 libc = "0.2.99"
-unicode-width = { version = "0.1", optional = true }
+unicode-display-width = { version = "0.3", optional = true }
 lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ are useful for more complex formatting.
 
 ## Unicode Width Support
 
-By default this crate depends on the `unicode-width` crate to calculate
+By default this crate depends on the `unicode-display-width` crate to calculate
 the width of terminal characters.  If you do not need this you can disable
-the `unicode-width` feature which will cut down on dependencies.
+the `unicode-display-width` feature which will cut down on dependencies.
 
 License: MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,15 @@
 //!
 //! # Unicode Width Support
 //!
-//! By default this crate depends on the `unicode-width` crate to calculate
+//! By default this crate depends on the `unicode-display-width` crate to calculate
 //! the width of terminal characters.  If you do not need this you can disable
-//! the `unicode-width` feature which will cut down on dependencies.
+//! the `unicode-display-width` feature which will cut down on dependencies.
 //!
 //! # Features
 //!
 //! By default all features are enabled.  The following features exist:
 //!
-//! * `unicode-width`: adds support for unicode width calculations
+//! * `unicode-display-width`: adds support for unicode width calculations
 //! * `ansi-parsing`: adds support for parsing ansi codes (this adds support
 //!   for stripping and taking ansi escape codes into account for length
 //!   calculations).

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -707,12 +707,11 @@ impl<'a, 'b> fmt::Display for Emoji<'a, 'b> {
 }
 
 fn str_width(s: &str) -> usize {
-    #[cfg(feature = "unicode-width")]
+    #[cfg(feature = "unicode-display-width")]
     {
-        use unicode_width::UnicodeWidthStr;
-        s.width()
+        unicode_display_width::width(s) as usize
     }
-    #[cfg(not(feature = "unicode-width"))]
+    #[cfg(not(feature = "unicode-display-width"))]
     {
         s.chars().count()
     }
@@ -720,12 +719,14 @@ fn str_width(s: &str) -> usize {
 
 #[cfg(feature = "ansi-parsing")]
 fn char_width(c: char) -> usize {
-    #[cfg(feature = "unicode-width")]
+    #[cfg(feature = "unicode-display-width")]
     {
-        use unicode_width::UnicodeWidthChar;
-        c.width().unwrap_or(0)
+        match unicode_display_width::is_double_width(c) {
+            true => 2,
+            false => 1,
+        }
     }
-    #[cfg(not(feature = "unicode-width"))]
+    #[cfg(not(feature = "unicode-display-width"))]
     {
         let _c = c;
         1
@@ -873,7 +874,7 @@ fn test_text_width() {
         measure_text_width(&s),
         if cfg!(feature = "ansi-parsing") {
             3
-        } else if cfg!(feature = "unicode-width") {
+        } else if cfg!(feature = "unicode-display-width") {
             17
         } else {
             21
@@ -882,7 +883,7 @@ fn test_text_width() {
 }
 
 #[test]
-#[cfg(all(feature = "unicode-width", feature = "ansi-parsing"))]
+#[cfg(all(feature = "unicode-display-width", feature = "ansi-parsing"))]
 fn test_truncate_str() {
     let s = format!("foo {}", style("bar").red().force_styling(true));
     assert_eq!(


### PR DESCRIPTION
This change had to be made in both crates in order to be updated correctly.
The console-rs crate has been bumped an extra version as a result of a behavior change of `char_width()` with the `unicode-display-width` feature enabled - it now returns always 1 or 2, never 0 as it used to.
The indicatif crate may also need to be bumped a full version as a result of the dependency change, but I'm not sure if you'd consider this a breaking change to the same degree, as it's not an advertised feature.

Related issue: https://github.com/console-rs/indicatif/issues/638
Related PR: https://github.com/console-rs/indicatif/pull/639