### PR TITLE
ci: Force older version of unicode-width for MSRV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,6 @@ lint:
 msrv-lock:
 	@cargo update -p proptest --precise=1.0.0
 	@cargo update -p byteorder --precise=1.4.0
+	@cargo update -p unicode-width --precise=0.1.12
 
 .PHONY: all doc build check test format format-check lint check-minver msrv-lock


### PR DESCRIPTION
unicode-width 0.1.13 added code which didn't compile with Rust 1.56