### PR TITLE
unicode-width: 0.1 -> 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ansi-parsing = []
 
 [dependencies]
 libc = "0.2.99"
-unicode-width = { version = "0.1", optional = true }
+unicode-width = { version = ">=0.1,<0.3", optional = true }
 lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
indicatif already depends on 0.2, so this helps to deduplicate my dependencies a bit.