### PR TITLE
.github: update branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   build-msrv:
     name: Build on MSRV (1.66)


### PR DESCRIPTION
The default branch is main, not master.

r? @djc
