### PR TITLE
feat: support gradients

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,9 @@ pub use crate::term::{
 };
 pub use crate::utils::{
     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
-    set_colors_enabled, set_colors_enabled_stderr, style, truncate_str, Alignment, Attribute,
-    Color, Emoji, Style, StyledObject,
+    set_colors_enabled, set_colors_enabled_stderr, set_true_colors_enabled,
+    set_true_colors_enabled_stderr, style, true_colors_enabled, true_colors_enabled_stderr,
+    truncate_str, Alignment, Attribute, Color, Emoji, Style, StyledObject,
 };
 
 #[cfg(feature = "ansi-parsing")]

--- a/src/term.rs
+++ b/src/term.rs
@@ -78,6 +78,11 @@ impl TermFeatures<'_> {
         is_a_color_terminal(self.0)
     }
 
+    /// Check if true colors are supported by this terminal.
+    pub fn true_colors_supported(&self) -> bool {
+        is_a_true_color_terminal(self.0)
+    }
+
     /// Check if this terminal is an msys terminal.
     ///
     /// This is sometimes useful to disable features that are known to not

--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -36,6 +36,16 @@ pub(crate) fn is_a_color_terminal(out: &Term) -> bool {
     }
 }
 
+pub(crate) fn is_a_true_color_terminal(out: &Term) -> bool {
+    if !is_a_color_terminal(out) {
+        return false;
+    }
+    match env::var("COLORTERM") {
+        Ok(term) => term == "truecolor" || term == "24bit",
+        Err(_) => false,
+    }
+}
+
 fn c_result<F: FnOnce() -> libc::c_int>(f: F) -> io::Result<()> {
     let res = f();
     if res != 0 {

--- a/src/wasm_term.rs
+++ b/src/wasm_term.rs
@@ -29,6 +29,11 @@ pub(crate) fn is_a_color_terminal(_out: &Term) -> bool {
 }
 
 #[inline]
+pub(crate) fn is_a_true_color_terminal(_out: &Term) -> bool {
+    false
+}
+
+#[inline]
 pub(crate) fn terminal_size(_out: &Term) -> Option<(u16, u16)> {
     None
 }

--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -78,6 +78,20 @@ pub(crate) fn is_a_color_terminal(out: &Term) -> bool {
     enable_ansi_on(out)
 }
 
+pub(crate) fn is_a_true_color_terminal(out: &Term) -> bool {
+    if !is_a_color_terminal(out) {
+        return false;
+    }
+    // Powershell does not respect the COLORTERM var despite supporting true colors
+    // but other shells may respect it
+    if msys_tty_on(out) {
+        return match env::var("COLORTERM") {
+            Ok(term) => term == "truecolor" || term == "24bit",
+            Err(_) => true,
+        };
+    }
+}
+
 /// Enables or disables the `mode` flag on the given `HANDLE` and yields the previous mode.
 fn set_console_mode(handle: HANDLE, mode: CONSOLE_MODE, enable: bool) -> Option<CONSOLE_MODE> {
     unsafe {

--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -90,6 +90,7 @@ pub(crate) fn is_a_true_color_terminal(out: &Term) -> bool {
             Err(_) => true,
         };
     }
+    false
 }
 
 /// Enables or disables the `mode` flag on the given `HANDLE` and yields the previous mode.


### PR DESCRIPTION
As said on [this issue](https://github.com/console-rs/indicatif/issues/691), I said I would propose a PR.

![Screenshot From 2025-01-22 15-32-11](https://github.com/user-attachments/assets/c1052761-9e65-4c3e-a096-1d724b246b48)


# Notable elements and changes

- The API is fully backwards compatible, as `console` was a transitive dependency and I needed my project

- Add supports for multi-step gradients. If the terminal doesn't support "true colors", it will have no effect.

- utils functions to check/force true color support


From a `dotted_string`, you can use `[on_]gradient(_HEX_COLOR)+` 
For example: 
```rust
".magenta.gradient_E50000_FF8D00_FFEEOO_028121_004CFF_770088"
```
This will use a gradient on true colors terminals and fall back on the magenta color for other terminals.

From a `StyledObject<D>` perspective, use `.[on_]gradient(GradientColor)` to add a color to the gradient.


- This PR doesn't bring additional tests, as I want first to be sure the API is final

- The gradient support is heavily inspired by [Tinterm](https://github.com/bratish/Tinterm/)