### PR TITLE
Implement measure_text_width with no allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ test:
 	@cargo test
 	@cargo test --all-features
 	@cargo test --no-default-features
+	@cargo test --no-default-features --features ansi-parsing
+	@cargo test --no-default-features --features unicode-width
 
 check-minver:
 	@echo "MINVER CHECK"


### PR DESCRIPTION
I implemented that while working on optimizing something I don't remember, it might still be useful.

Also, I noticed that the test for this function was wrong when only using the `unicode-width` feature (probably due to some update in the corresponding?).

```bash
# Running on origin/main
$ cargo test --no-default-features -F unicode-width 
running 6 tests
test utils::test_pad_str ... ok
test utils::test_truncate_str_no_ansi ... ok
test utils::test_pad_str_with ... ok
test utils::test_text_width ... FAILED
test utils::test_attributes_many ... ok
test utils::test_attributes_single ... ok

failures:

---- utils::test_text_width stdout ----
thread 'utils::test_text_width' panicked at 'assertion failed: `(left == right)`
  left: `21`,
 right: `17`', src/utils.rs:940:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I've completed the Makefile so that all possible sets of feature are tested, as the project is not too big I don't think it's too heavy.