### PR TITLE
fix: clippy lint (clippy::unnecessary cast)

### DIFF
--- a/src/unix_term.rs
+++ b/src/unix_term.rs
@@ -59,7 +59,7 @@ pub(crate) fn terminal_size(out: &Term) -> Option<(u16, u16)> {
         winsize
     };
     if winsize.ws_row > 0 && winsize.ws_col > 0 {
-        Some((winsize.ws_row as u16, winsize.ws_col as u16))
+        Some((winsize.ws_row, winsize.ws_col))
     } else {
         None
     }


### PR DESCRIPTION
From https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast:

> warning: casting to the same type is unnecessary (`u16` -> `u16`)