### PR TITLE
chore: pin once_cell<1.21 to enforce MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ansi-parsing = []
 
 [dependencies]
 libc = "0.2.99"
-once_cell = "1.8"
+once_cell = "1.8,<1.21" # version 1.21 requires Rust >= 1.70
 unicode-width = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Latest `once_cell` version only supports Rust >= 1.70 :

```bash
$ cargo update
$ cargo check
error: package `once_cell v1.21.0` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.66.1
Either upgrade to rustc 1.70 or newer, or use
cargo update -p once_cell@1.21.0 --precise ver
where `ver` is the latest version of `once_cell` supporting rustc 1.66.1
```

EDIT : BTW, 1.21 has no fixes or any change relevant to us : https://github.com/matklad/once_cell/blob/master/CHANGELOG.md#1210