### PR TITLE
Add features to work with no_std, and with alloc in no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,15 @@ readme = "README.md"
 rust-version = "1.66"
 
 [features]
-default = ["unicode-width", "ansi-parsing"]
+std = ["dep:libc", "dep:once_cell", "alloc"]
+alloc = []
+default = ["unicode-width", "ansi-parsing", "std"]
 windows-console-colors = ["ansi-parsing"]
 ansi-parsing = []
 
 [dependencies]
-libc = "0.2.99"
-once_cell = "1.8"
+libc = { version = "0.2.99", optional = true }
+once_cell = { version = "1.8", optional = true }
 unicode-width = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,5 +1,6 @@
-use std::{
-    borrow::Cow,
+#[cfg(feature = "alloc")]
+use alloc::{borrow::Cow, string::String};
+use core::{
     iter::{FusedIterator, Peekable},
     str::CharIndices,
 };
@@ -185,6 +186,7 @@ fn find_ansi_code_exclusive(it: &mut Peekable<CharIndices>) -> Option<(usize, us
     }
 }
 
+#[cfg(feature = "alloc")]
 /// Helper function to strip ansi codes.
 pub fn strip_ansi_codes(s: &str) -> Cow<str> {
     let mut char_it = s.char_indices().peekable();

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 /// Key mapping
 ///
 /// This is an incomplete mapping of keys that are supported for reading

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,25 +77,37 @@
 //!   calculations).
 
 #![warn(unreachable_pub)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
+#[cfg(feature = "alloc")]
 pub use crate::kb::Key;
+#[cfg(feature = "std")]
 pub use crate::term::{
     user_attended, user_attended_stderr, Term, TermFamily, TermFeatures, TermTarget,
 };
+#[cfg(feature = "std")]
 pub use crate::utils::{
     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
     set_colors_enabled, set_colors_enabled_stderr, style, truncate_str, Alignment, Attribute,
     Color, Emoji, Style, StyledObject,
 };
 
+#[cfg(all(feature = "ansi-parsing", feature = "alloc"))]
+pub use crate::ansi::strip_ansi_codes;
 #[cfg(feature = "ansi-parsing")]
-pub use crate::ansi::{strip_ansi_codes, AnsiCodeIterator};
+pub use crate::ansi::AnsiCodeIterator;
 
+#[cfg(feature = "std")]
 mod common_term;
+#[cfg(feature = "alloc")]
 mod kb;
+#[cfg(feature = "std")]
 mod term;
-#[cfg(all(unix, not(target_arch = "wasm32")))]
+#[cfg(all(unix, not(target_arch = "wasm32"), feature = "std"))]
 mod unix_term;
+#[cfg(feature = "std")]
 mod utils;
 #[cfg(target_arch = "wasm32")]
 mod wasm_term;


### PR DESCRIPTION
Closes #255 

3 levels:
no_std without alloc: some stuff works
no_std with alloc: some more stuff works
std: everything works

Tested by using `console::strip_ansi_codes` in [my OS](https://github.com/ChocolateLoverRaj/rust-os-tutorial), on `x86_64-unknown-none` with the `alloc` feature.